### PR TITLE
关于anyMatch的短路操作，应该发生在是第一个 true，而不是第一个 false。

### DIFF
--- a/docs/book/14-Streams.md
+++ b/docs/book/14-Streams.md
@@ -1946,7 +1946,7 @@ Lambda 表达式中的第一个参数 `fr0` 是 `reduce()` 中上一次调用的
 ### 匹配
 
 - `allMatch(Predicate)` ：如果流的每个元素提供给 **Predicate** 都返回 true ，结果返回为 true。在第一个 false 时，则停止执行计算。
-- `anyMatch(Predicate)`：如果流的任意一个元素提供给 **Predicate** 返回 true ，结果返回为 true。在第一个 false 是停止执行计算。
+- `anyMatch(Predicate)`：如果流的任意一个元素提供给 **Predicate** 返回 true ，结果返回为 true。在第一个 true 是停止执行计算。
 - `noneMatch(Predicate)`：如果流的每个元素提供给 **Predicate** 都返回 false 时，结果返回为 true。在第一个 true 时停止执行计算。
 
 我们已经在 `Prime.java` 中看到了 `noneMatch()` 的示例；`allMatch()` 和 `anyMatch()` 的用法基本上是等同的。下面我们来探究一下短路行为。为了消除冗余代码，我们创建了 `show()`。首先我们必须知道如何统一地描述这三个匹配器的操作，然后再将其转换为 **Matcher** 接口。代码示例：


### PR DESCRIPTION
anyMatch的短路操作，描述错误。

原文：
anyMatch(Predicate): Returns true if any element of the stream produces true when provided to the supplied Predicate. This will short-circuit upon the first **true**.